### PR TITLE
fix: sync PendingEvent dynamic with user info

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -29,6 +29,7 @@ func main() {
 	fixedEventRouter.HandleFunc("", utils.FixedEventHandler).Methods("GET", "POST")
 	fixedEventRouter.HandleFunc("/{fixedEventId}", utils.FixedEventWithIdHandler).Methods("GET", "PATCH", "DELETE")
 	fixedEventRouter.HandleFunc("/{fixedEventId}/candidate", utils.FixedEventCandidateHandler).Methods("PUT", "DELETE")
+	fixedEventRouter.HandleFunc("/{fixedEventId}/reminder", utils.FixedEventReminderHandler).Methods("GET", "POST", "PUT", "DELETE")
 
 	pendingEventRouter := mainRouter.PathPrefix("/pendingEvents").Subrouter()
 	pendingEventRouter.HandleFunc("", utils.PendingEventHandler).Methods("GET", "POST")
@@ -37,9 +38,6 @@ func main() {
 
 	invitationRouter := mainRouter.PathPrefix("/invitation").Subrouter()
 	invitationRouter.HandleFunc("/{pendingEventId}", utils.InvitationHandler).Methods("GET")
-
-	reminderRouter := mainRouter.PathPrefix("/reminder").Subrouter()
-	reminderRouter.HandleFunc("/{fixedEventId}", utils.ReminderHandler).Methods("GET", "PATCH")
 
 	logMiddleWare := utils.NewLogMiddleware(logger)
 	mainRouter.Use(logMiddleWare.Func())

--- a/backend/utils/db_struct.go
+++ b/backend/utils/db_struct.go
@@ -1,12 +1,21 @@
 package utils
 
-type pendingEventUser struct {
+type PendingEventUser struct {
+	UserId string `json:"userId" bson:"userId"`
+}
+
+type PendingEventUserWithInfo struct {
 	UserId           string `json:"userId" bson:"userId"`
 	UserName         string `json:"userName" bson:"userName"`
 	UserProfileImage string `json:"userProfileImage" bson:"userProfileImage"`
 }
 
-type fixedEventUser struct {
+type FixedEventUser struct {
+	UserId     string `json:"userId" bson:"userId"`
+	UserStatus string `json:"userStatus" bson:"userStatus"`
+}
+
+type FixedEventUserWithInfo struct {
 	UserId           string `json:"userId" bson:"userId"`
 	UserName         string `json:"userName" bson:"userName"`
 	UserProfileImage string `json:"userProfileImage" bson:"userProfileImage"`
@@ -23,20 +32,20 @@ type Token struct {
 
 type User struct {
 	UserId           string `json:"userId" bson:"userId"`
-	Name             string `json:"name" bson:"name"`
-	Email            string `json:"email" bson:"email"`
-	PhoneNumber      string `json:"phoneNumber" bson:"phoneNumber"`
-	ProfileImage     string `json:"profileImage" bson:"profileImage"`
-	Timezone         string `json:"timezone" bson:"timezone"`
+	Name             string `json:"userName" bson:"name"`
+	Email            string `json:"userEmail" bson:"email"`
+	PhoneNumber      string `json:"userPhoneNumber" bson:"phoneNumber"`
+	ProfileImage     string `json:"userProfileImage" bson:"profileImage"`
+	Timezone         string `json:"userTimezone" bson:"timezone"`
 	KakaoId          string `json:"kakaoId" bson:"kakaoId"`
-	GoogleCalendarId string `json:"googleCalendarId" bson:"googleCalendarId"`
+	GoogleCalendarId string `json:"userGoogleCalenderId" bson:"googleCalenderId"`
 	Token            Token  `json:"userToken" bson:"token"`
 }
 
 type PendingEvent struct {
 	PendingEventId      string               `json:"eventId" bson:"pendingEventId"`
 	Title               string               `json:"eventTitle" bson:"title"`
-	HostUser            pendingEventUser     `json:"eventHost" bson:"hostUser"`
+	HostUser            PendingEventUser     `json:"eventHost" bson:"hostUser"`
 	Description         string               `json:"eventDescription" bson:"description"`
 	Duration            int                  `json:"eventTimeDuration" bson:"duration"`
 	EventTimeCandidates []EventTimeCandidate `json:"eventTimeCandidates" bson:"eventTimeCandidates"`
@@ -62,7 +71,7 @@ type DeclinedSurvey struct {
 
 type FixedEvent struct {
 	FixedEventId string           `json:"eventId" bson:"fixedEventId"`
-	HostUser     fixedEventUser   `json:"eventHost" bson:"hostUser"`
+	HostUser     FixedEventUser   `json:"eventHost" bson:"hostUser"`
 	Title        string           `json:"eventTitle" bson:"title"`
 	Description  string           `json:"eventDescription" bson:"description"`
 	Duration     int              `json:"eventTimeDuration" bson:"duration"`
@@ -70,13 +79,13 @@ type FixedEvent struct {
 	PlaceAddress string           `json:"eventPlace" bson:"placeAddress"`
 	PlaceUrl     string           `json:"eventZoomAddress" bson:"placeUrl"`
 	Attachment   string           `json:"eventAttachment" bson:"attachment"`
-	Participants []fixedEventUser `json:"participants" bson:"participants"`
+	Participants []FixedEventUser `json:"participants" bson:"participants"`
 	IsDisabled   bool             `json:"isDisabled" bson:"isDisabled"`
 }
 
 type Reminder struct {
-	ReminderId   string   `json:"reminderId" bson:"reminderId"`
 	FixedEventId string   `json:"fixedEventId" bson:"fixedEventId"`
 	UserId       string   `json:"userId" bson:"userId"`
 	Date         unixTime `json:"date" bson:"date"`
+	TimeDelta    unixTime `json:"timeDelta" bson:"timeDelta"`
 }

--- a/backend/utils/reminder.go
+++ b/backend/utils/reminder.go
@@ -1,5 +1,98 @@
 package utils
 
-func patchReminder() {
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"net/http"
+)
+
+func getReminder(w http.ResponseWriter, serviceAuthToken string, feId string) {
+	client := connect()
+	defer disconnect(client)
+
+	userCol := client.Database("kezuler").Collection("user")
+	var hostUser User
+	err := userCol.FindOne(context.TODO(), bson.M{"token.accessToken": serviceAuthToken}).Decode(&hostUser)
+	if err == mongo.ErrNoDocuments {
+		fmt.Printf("No user was found with given token: %s\n", serviceAuthToken)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	reminderCol := client.Database("kezuler").Collection("reminder")
+	var targetReminder Reminder
+	err = reminderCol.FindOne(context.TODO(), bson.D{{"fixedEventId", feId}}).Decode(&targetReminder)
+
+	if err == mongo.ErrNoDocuments {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	jsonRes, err := json.Marshal(targetReminder)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonRes)
+}
+
+func postReminder(w http.ResponseWriter, serviceAuthToken string, feId string, timeDelta unixTime) {
+	client := connect()
+	defer disconnect(client)
+
+	userCol := client.Database("kezuler").Collection("user")
+	var hostUser User
+	err := userCol.FindOne(context.TODO(), bson.M{"token.accessToken": serviceAuthToken}).Decode(&hostUser)
+	if err == mongo.ErrNoDocuments {
+		fmt.Printf("No user was found with given token: %s\n", serviceAuthToken)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	fixedEventCol := client.Database("kezuler").Collection("fixedEvent")
+	var targetEvent FixedEvent
+	err = fixedEventCol.FindOne(context.TODO(), bson.D{{"fixedEventId", feId}}).Decode(&targetEvent)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if targetEvent.HostUser.UserId != hostUser.UserId && findUserInFixedEventUsers(hostUser, targetEvent.Participants) == -1 {
+		http.Error(w, "Cannot handle reminder with unauthorized user.", http.StatusUnauthorized)
+		return
+	}
+
+	newReminder := Reminder{
+		FixedEventId: targetEvent.FixedEventId,
+		UserId:       hostUser.UserId,
+		Date:         targetEvent.Date - timeDelta,
+		TimeDelta:    timeDelta,
+	}
+
+	reminderCol := client.Database("kezuler").Collection("reminder")
+	_, err = reminderCol.InsertOne(context.TODO(), newReminder)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	jsonRes, err := json.Marshal(newReminder)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonRes)
+}
+
+func putReminder(w http.ResponseWriter, serviceAuthToken string, feId string, timeDelta unixTime) {
 
 }

--- a/backend/utils/struct.go
+++ b/backend/utils/struct.go
@@ -80,26 +80,27 @@ type EventTimeCandidate struct {
 	PossibleUsers []AcceptUser `json:"possibleUsers" bson:"possibleUsers"`
 }
 
-type PendingEventClaims struct {
-	EventId             string               `json:"eventId"`
-	EventHost           pendingEventUser     `json:"eventHost"`
-	EventTitle          string               `json:"eventTitle"`
-	EventDescription    string               `json:"eventDescription"`
-	EventTimeDuration   int                  `json:"eventTimeDuration"`
-	DeclinedUsers       []DeclineUser        `json:"declinedUsers"`
-	EventTimeCandidates []EventTimeCandidate `json:"eventTimeCandidates"`
-	EventZoomAddress    interface{}          `json:"eventZoomAddress"`
-	EventPlace          string               `json:"eventPlace"`
-	EventAttachment     string               `json:"eventAttachment"`
+type EventTimeCandidateWithInfo struct {
+	EventStartsAt unixTime             `json:"eventStartsAt" bson:"eventStartsAt"`
+	PossibleUsers []AcceptUserWithInfo `json:"possibleUsers" bson:"possibleUsers"`
 }
 
 type AcceptUser struct {
+	UserId string `json:"userId" bson:"userId"`
+}
+
+type AcceptUserWithInfo struct {
 	UserId           string `json:"userId" bson:"userId"`
 	UserName         string `json:"userName" bson:"userName"`
 	UserProfileImage string `json:"userProfileImage" bson:"userProfileImage"`
 }
 
 type DeclineUser struct {
+	UserId            string `json:"userId" bson:"userId"`
+	UserDeclineReason string `json:"userDeclineReason" bson:"userDeclineReason"`
+}
+
+type DeclineUserWithInfo struct {
 	UserId            string `json:"userId" bson:"userId"`
 	UserName          string `json:"userName" bson:"userName"`
 	UserProfileImage  string `json:"userProfileImage" bson:"userProfileImage"`
@@ -128,4 +129,35 @@ type DeletePendingEventCandidatePayload struct {
 type PatchFixedEventWithIdPayload struct {
 	EventTitle       string `json:"eventTitle,omitempty" bson:"title,omitempty"`
 	EventDescription string `json:"eventDescription,omitempty" bson:"description,omitempty"`
+}
+
+type PostRemindPayload struct {
+	TimeDelta unixTime `json:"timeDelta" bson:"timeDelta"`
+}
+
+type PendingEventClaims struct {
+	PendingEventId      string                       `json:"eventId" bson:"pendingEventId"`
+	Title               string                       `json:"eventTitle" bson:"title"`
+	HostUser            PendingEventUserWithInfo     `json:"eventHost" bson:"hostUser"`
+	Description         string                       `json:"eventDescription" bson:"description"`
+	Duration            int                          `json:"eventTimeDuration" bson:"duration"`
+	EventTimeCandidates []EventTimeCandidateWithInfo `json:"eventTimeCandidates" bson:"eventTimeCandidates"`
+	DeclinedUsers       []DeclineUserWithInfo        `json:"declinedUsers" bson:"declinedUsers"`
+	PlaceAddress        string                       `json:"eventPlace" bson:"placeAddress"`
+	PlaceUrl            string                       `json:"eventZoomAddress" bson:"placeUrl"`
+	Attachment          string                       `json:"eventAttachment" bson:"attachment"`
+}
+
+type FixedEventClaims struct {
+	FixedEventId string                   `json:"eventId" bson:"fixedEventId"`
+	HostUser     FixedEventUserWithInfo   `json:"eventHost" bson:"hostUser"`
+	Title        string                   `json:"eventTitle" bson:"title"`
+	Description  string                   `json:"eventDescription" bson:"description"`
+	Duration     int                      `json:"eventTimeDuration" bson:"duration"`
+	Date         unixTime                 `json:"eventTimeStartsAt" bson:"date"`
+	PlaceAddress string                   `json:"eventPlace" bson:"placeAddress"`
+	PlaceUrl     string                   `json:"eventZoomAddress" bson:"placeUrl"`
+	Attachment   string                   `json:"eventAttachment" bson:"attachment"`
+	Participants []FixedEventUserWithInfo `json:"participants" bson:"participants"`
+	IsDisabled   bool                     `json:"isDisabled" bson:"isDisabled"`
 }


### PR DESCRIPTION
### PR Description

- `reminder`에 대한 CRUD를 추가했습니다. (알림톡 연동은 출시 후에 진행합니다.)
- `pendingEvent`의 user 정보에 대한 scheme을 수정했습니다. (API 호출 시 동적으로 가져오도록 수정, DB 구조 수정)