### PR TITLE
add: support for FixedEvent to do dynamic sync with users, GET /user

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -21,9 +21,9 @@ func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	mainRouter := mux.NewRouter()
 
-	userRouter := mainRouter.PathPrefix("/users").Subrouter()
+	userRouter := mainRouter.PathPrefix("/user").Subrouter()
 	userRouter.HandleFunc("", utils.UserHandler).Methods("POST")
-	userRouter.HandleFunc("/{userId}", utils.UserWithIdHandler).Methods("GET", "PATCH", "DELETE")
+	userRouter.HandleFunc("", utils.UserWithTokenHandler).Methods("GET", "PATCH", "DELETE")
 
 	fixedEventRouter := mainRouter.PathPrefix("/fixedEvents").Subrouter()
 	fixedEventRouter.HandleFunc("", utils.FixedEventHandler).Methods("GET", "POST")

--- a/backend/utils/handler.go
+++ b/backend/utils/handler.go
@@ -25,7 +25,7 @@ func UserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func UserWithIdHandler(w http.ResponseWriter, r *http.Request) {
+func UserWithTokenHandler(w http.ResponseWriter, r *http.Request) {
 	serviceAuthToken := r.Header.Get("Authorization")
 	splitToken := strings.Split(serviceAuthToken, "Bearer")
 	if len(splitToken) != 2 {
@@ -203,6 +203,8 @@ func FixedEventReminderHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			putReminder(w, serviceAuthToken, feId, payload.TimeDelta)
 		}
+	} else if r.Method == "DELETE" {
+		deleteReminder(w, serviceAuthToken, feId)
 	} else {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 	}

--- a/backend/utils/reminder.go
+++ b/backend/utils/reminder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"net/http"
 )
 
@@ -24,7 +25,7 @@ func getReminder(w http.ResponseWriter, serviceAuthToken string, feId string) {
 
 	reminderCol := client.Database("kezuler").Collection("reminder")
 	var targetReminder Reminder
-	err = reminderCol.FindOne(context.TODO(), bson.D{{"fixedEventId", feId}}).Decode(&targetReminder)
+	err = reminderCol.FindOne(context.TODO(), bson.M{"fixedEventId": feId, "userId": hostUser.UserId}).Decode(&targetReminder)
 
 	if err == mongo.ErrNoDocuments {
 		w.WriteHeader(http.StatusNoContent)
@@ -77,7 +78,7 @@ func postReminder(w http.ResponseWriter, serviceAuthToken string, feId string, t
 	}
 
 	reminderCol := client.Database("kezuler").Collection("reminder")
-	_, err = reminderCol.InsertOne(context.TODO(), newReminder)
+	_, err = reminderCol.UpdateOne(context.TODO(), bson.M{"fixedEventId": newReminder.FixedEventId, "userId": newReminder.UserId}, bson.M{"$setOnInsert": newReminder}, options.Update().SetUpsert(true))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -94,5 +95,85 @@ func postReminder(w http.ResponseWriter, serviceAuthToken string, feId string, t
 }
 
 func putReminder(w http.ResponseWriter, serviceAuthToken string, feId string, timeDelta unixTime) {
+	client := connect()
+	defer disconnect(client)
 
+	userCol := client.Database("kezuler").Collection("user")
+	var hostUser User
+	err := userCol.FindOne(context.TODO(), bson.M{"token.accessToken": serviceAuthToken}).Decode(&hostUser)
+	if err == mongo.ErrNoDocuments {
+		fmt.Printf("No user was found with given token: %s\n", serviceAuthToken)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	fixedEventCol := client.Database("kezuler").Collection("fixedEvent")
+	var targetEvent FixedEvent
+	err = fixedEventCol.FindOne(context.TODO(), bson.D{{"fixedEventId", feId}}).Decode(&targetEvent)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if targetEvent.HostUser.UserId != hostUser.UserId && findUserInFixedEventUsers(hostUser, targetEvent.Participants) == -1 {
+		http.Error(w, "Cannot handle reminder with unauthorized user.", http.StatusUnauthorized)
+		return
+	}
+
+	updatedReminder := Reminder{
+		FixedEventId: targetEvent.FixedEventId,
+		UserId:       hostUser.UserId,
+		Date:         targetEvent.Date - timeDelta,
+		TimeDelta:    timeDelta,
+	}
+
+	reminderCol := client.Database("kezuler").Collection("reminder")
+	reminderCol.FindOneAndUpdate(context.TODO(), bson.M{"fixedEventId": targetEvent.FixedEventId, "userId": targetEvent.HostUser.UserId}, updatedReminder)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	jsonRes, err := json.Marshal(updatedReminder)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonRes)
+}
+
+func deleteReminder(w http.ResponseWriter, serviceAuthToken string, feId string) {
+	client := connect()
+	defer disconnect(client)
+
+	userCol := client.Database("kezuler").Collection("user")
+	var hostUser User
+	err := userCol.FindOne(context.TODO(), bson.M{"token.accessToken": serviceAuthToken}).Decode(&hostUser)
+	if err == mongo.ErrNoDocuments {
+		fmt.Printf("No user was found with given token: %s\n", serviceAuthToken)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	fixedEventCol := client.Database("kezuler").Collection("fixedEvent")
+	var targetEvent FixedEvent
+	err = fixedEventCol.FindOne(context.TODO(), bson.D{{"fixedEventId", feId}}).Decode(&targetEvent)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if targetEvent.HostUser.UserId != hostUser.UserId && findUserInFixedEventUsers(hostUser, targetEvent.Participants) == -1 {
+		http.Error(w, "Cannot handle reminder with unauthorized user.", http.StatusUnauthorized)
+		return
+	}
+
+	reminderCol := client.Database("kezuler").Collection("reminder")
+	_, err = reminderCol.DeleteOne(context.TODO(), bson.M{"fixedEventId": targetEvent.FixedEventId, "userId": hostUser.UserId})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/utils/struct.go
+++ b/backend/utils/struct.go
@@ -25,11 +25,11 @@ type AuthTokenClaims struct {
 }
 
 type UserToken struct {
-	TokenType             string `json:"tokenType"`
-	AccessToken           string `json:"accessToken"`
-	AccessTokenExpiresIn  int    `json:"accessTokenExpiresIn"`
-	RefreshToken          string `json:"refreshToken"`
-	RefreshTokenExpiresIn int    `json:"refreshTokenExpiresIn"`
+	TokenType             string   `json:"tokenType"`
+	AccessToken           string   `json:"accessToken"`
+	AccessTokenExpiresIn  unixTime `json:"accessTokenExpiresIn"`
+	RefreshToken          string   `json:"refreshToken"`
+	RefreshTokenExpiresIn unixTime `json:"refreshTokenExpiresIn"`
 }
 
 type PostUserClaims struct {


### PR DESCRIPTION
### PR description

- `FixedEvents`에 대해 User와 동적 Sync가 가능하도록 코드를 수정하였습니다.
- `/users/<userId>`를 단순 토큰만 이용하도록 `/user`로 수정하였습니다.
- `GET /user` API에 대한 지원을 추가하였습니다.