### PR TITLE
fix: sync db struct to POST /user

### DIFF
--- a/backend/utils/db_struct.go
+++ b/backend/utils/db_struct.go
@@ -37,7 +37,7 @@ type User struct {
 	PhoneNumber      string `json:"userPhoneNumber" bson:"phoneNumber"`
 	ProfileImage     string `json:"userProfileImage" bson:"profileImage"`
 	Timezone         string `json:"userTimezone" bson:"timezone"`
-	KakaoId          string `json:"kakaoId" bson:"kakaoId"`
+	KakaoId          int    `json:"userKakaoId" bson:"kakaoId"`
 	GoogleCalendarId string `json:"userGoogleCalenderId" bson:"googleCalenderId"`
 	Token            Token  `json:"userToken" bson:"token"`
 }


### PR DESCRIPTION
PR description

• KakaoId의 Type이 int로 받아와지는 것을 DB에 반영합니다.