### PR TITLE
[#164] Modfiy : 수정 페이지 input-width 100%

### DIFF
--- a/frontend/kezuler-fe/src/styles/OverviewModal.scss
+++ b/frontend/kezuler-fe/src/styles/OverviewModal.scss
@@ -472,6 +472,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .overview-title-input {


### PR DESCRIPTION
안드로이드 폰에서 수정 페이지 input 창 밑으로 내려가면 패딩 오버해서 css 통일 안되는 것 관련입니다.
width auto -> width 100%