### PR TITLE
[#171] feat : in app 브라우저 전환

### DIFF
--- a/frontend/kezuler-fe/public/index.html
+++ b/frontend/kezuler-fe/public/index.html
@@ -100,6 +100,55 @@
         let vh = window.innerHeight * 0.01;
         document.documentElement.style.setProperty('--vh', `${vh}px`);
       });
+
+      document.addEventListener('DOMContentLoaded', ready);
+      function ready() {
+        let Url = location.href;
+        let Agent = navigator.userAgent.toLowerCase();
+        let chromeNewTab =
+          'intent://' +
+          location.href.replace(/https?:\/\//i, '') +
+          '#Intent;scheme=http;package=com.android.chrome;end';
+
+        if (navigator.userAgent.match(/iPhone|iPad/i)) {
+          // 아이폰 접속 경우
+          console.log('[window ready] : [접속 모바일] : ' + '[아이폰]');
+          // 아이폰의 경우 인앱브라우저 전환불가
+        } else {
+          // 안드로이드 접속 경우
+          console.log('[window ready] : [접속 모바일] : ' + '[안드로이드]');
+          // 카카오 인앱 브라우저 닫기
+          if (Agent.includes('kakao')) {
+            location.href = 'kakaotalk://inappbrowser/close';
+            location.href = chromeNewTab;
+          }
+          // 네이버 인앱 브라우저 닫기
+          else if (Agent.includes('naver')) {
+            self.close();
+            location.href = chromeNewTab;
+          }
+          // 인스타 인앱 브라우저 닫기
+          else if (Agent.includes('instagram')) {
+            location.href = 'instagram://inappbrowser/close';
+            location.href = chromeNewTab;
+          }
+        }
+      }
+      const copytoclipboard = (url) => {
+        const textArea = document.createElement('textarea');
+        document.body.appendChild(textArea);
+        textArea.value = url;
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+      };
+      const inappbrowserout = () => {
+        copytoclipboard(location.href);
+        alert(
+          'URL주소가 복사되었습니다.\n\nSafari가 열리면 주소창을 길게 터치한 뒤, "붙여놓기 및 이동"를 누르면 정상적으로 이용하실 수 있습니다.'
+        );
+        location.href = 'x-web-search://?';
+      };
     </script>
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/frontend/kezuler-fe/src/components/my-page/MyPageMain.tsx
+++ b/frontend/kezuler-fe/src/components/my-page/MyPageMain.tsx
@@ -135,11 +135,30 @@ function MyPageMain({ goToEdit }: Props) {
     flow: 'auth-code',
     scope: GOOGLE_LOGIN_SCOPE,
   });
+
+  const checkIos = () => {
+    if (navigator.userAgent.match(/iPhone|iPad/i)) {
+      const mobile = document.createElement('meta');
+      mobile.name = 'viewport';
+      mobile.content =
+        'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no, minimal-ui';
+      document.getElementsByTagName('head')[0].appendChild(mobile);
+      const fonts = document.createElement('link');
+      fonts.href =
+        'https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff';
+      document.getElementsByTagName('head')[0].appendChild(fonts);
+      document.body.innerHTML =
+        "<style>body{margin:0;padding:0;font-family: 'Pretendard', sans-serif;overflow: hidden;height: 100%;}</style><h2 style='padding-top:50px; text-align:center;font-family: 'Noto Sans KR', sans-serif;'>인앱브라우저 호환문제로 인해<br />Safari로 접속해야합니다.</h2><article style='text-align:center; font-size:17px; word-break:keep-all;color:#999;'>아래 버튼을 눌러 Safari를 실행해주세요<br />Safari가 열리면, 주소창을 길게 터치한 뒤,<br />'붙여놓기 및 이동'을 누르면<br />정상적으로 이용할 수 있습니다.<br /><br /><button onclick='inappbrowserout();' style='min-width:180px;margin-top:10px;height:54px;font-weight: 700;background-color:#fad94f;color:#000;border-radius: 4px;font-size:17px;border:0;'>Safari로 열기</button></article><img style='width:70%;margin:50px 15% 0 15%' src='https://tistory3.daumcdn.net/tistory/1893869/skin/images/inappbrowserout.jpeg' />";
+    } else {
+      connectGoogle();
+    }
+  };
+
   const handleGooglelogin = () => {
     openDialog({
       title: `구글 캘린더 연동`,
       description: '연동시, 다가오는 모든 일정이 \n 구글 캘린더에 연동됩니다.',
-      onConfirm: connectGoogle,
+      onConfirm: checkIos,
     });
   };
 


### PR DESCRIPTION
## 변경 사항
- android의 경우 kakao , naver , instagram 인앱 브라우저를 탈출하여 chrome에서 새로 생성합니다.
- ios 는 safari로 전환이 현재 불가능하여 , 구글 캘린더 토글버튼 on 클릭시 **사파리로 복사 붙여넣기 유도하는** 페이지로 이동

## 참고 사항
ios 사파리 복사 붙여넣기 유도하는 버튼 딜레이가 좀 있음