### PR TITLE
[#185] Modify : 장소창 arrow(더보기) 버튼 추가 / 내용 더보기 - 접기 삭제

### DIFF
--- a/frontend/kezuler-fe/src/components/main-page/overview-modal/OverviewBody.tsx
+++ b/frontend/kezuler-fe/src/components/main-page/overview-modal/OverviewBody.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { Button } from '@mui/material';
 import classNames from 'classnames';
 import { format } from 'date-fns/esm';
@@ -110,11 +111,29 @@ function OverviewBody({ eventDate, event, isCanceled, isPassed }: Props) {
       <div
         className={classNames('overview-section-place', {
           'is-ellipsis': isEllipsisActive,
+          'is-fold': foldEllipsis,
         })}
       >
         {addressType === 'OFF' ? (
           <>
             <LocIcon />
+            {isEllipsisActive ? (
+              !foldEllipsis ? (
+                <KeyboardArrowDownIcon
+                  onClick={handleFoldEllipsis}
+                  className={classNames('overview-section-place', {
+                    'is-ellipsis': isEllipsisActive,
+                  })}
+                />
+              ) : (
+                <KeyboardArrowUpIcon
+                  onClick={handleFoldEllipsis}
+                  className={classNames('overview-section-place', {
+                    'is-ellipsis': isEllipsisActive,
+                  })}
+                />
+              )
+            ) : null}
             <span
               className={classNames('overview-section-fold', {
                 'is-fold': foldEllipsis,
@@ -123,39 +142,43 @@ function OverviewBody({ eventDate, event, isCanceled, isPassed }: Props) {
             >
               {addressDetail}
             </span>
-            {isEllipsisActive && (
-              <KeyboardArrowDownIcon
-                onClick={handleFoldEllipsis}
-                className={classNames('overview-section-place', {
-                  'is-ellipsis': isEllipsisActive,
-                })}
-              />
-            )}
           </>
         ) : (
           <>
             <PCIcon />
             {addressDetail ? (
               <>
+                {isEllipsisActive ? (
+                  !foldEllipsis ? (
+                    <KeyboardArrowDownIcon
+                      onClick={handleFoldEllipsis}
+                      className={classNames('overview-section-place', {
+                        'is-ellipsis': isEllipsisActive,
+                      })}
+                    />
+                  ) : (
+                    <KeyboardArrowUpIcon
+                      onClick={handleFoldEllipsis}
+                      className={classNames('overview-section-place', {
+                        'is-ellipsis': isEllipsisActive,
+                      })}
+                    />
+                  )
+                ) : null}
                 <a
                   id="addressDetail"
                   href={addressDetail}
                   target="_blank"
                   rel="noreferrer"
-                  className={classNames('overview-section-fold', {
-                    'is-fold': foldEllipsis,
-                  })}
                 >
-                  <span>{addressDetail}</span>
-                </a>
-                {isEllipsisActive && (
-                  <KeyboardArrowDownIcon
-                    onClick={handleFoldEllipsis}
-                    className={classNames('overview-section-place', {
-                      'is-ellipsis': isEllipsisActive,
+                  <span
+                    className={classNames('overview-section-fold', {
+                      'is-fold': foldEllipsis,
                     })}
-                  />
-                )}
+                  >
+                    {addressDetail}
+                  </span>
+                </a>
               </>
             ) : (
               <span>{'온라인'}</span>

--- a/frontend/kezuler-fe/src/styles/OverviewModal.scss
+++ b/frontend/kezuler-fe/src/styles/OverviewModal.scss
@@ -219,7 +219,6 @@
   .overview-section-attachment-link {
     color: #6695d8;
     text-decoration: underline;
-
     flex: 1;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -244,14 +243,26 @@
       overflow: hidden;
       flex: 1;
       white-space: nowrap;
+      &.is-fold {
+        text-overflow: clip;
+        overflow: scroll;
+        white-space: normal;
+        word-break: break-all;
+      }
     }
 
-    // span {
-    //   text-overflow: ellipsis;
-    //   overflow: hidden;
-    //   flex: 1;
-    //   white-space: nowrap;
-    // }
+    span {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      flex: 1;
+      white-space: nowrap;
+      &.is-fold {
+        // text-overflow: clip;
+        overflow: scroll;
+        white-space: normal;
+        word-break: break-all;
+      }
+    }
 
     svg {
       margin-right: 4px;
@@ -271,21 +282,17 @@
       }
     }
 
+    .overview-section-fold {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      flex: 1;
+      white-space: nowrap;
+    }
+
     .overview-section-copy-btn {
       svg {
         margin-right: 1px;
       }
-    }
-  }
-
-  .overview-section-fold {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    flex: 1;
-    white-space: nowrap;
-    &.is-fold {
-      text-overflow: clip;
-      white-space: normal;
     }
   }
 }


### PR DESCRIPTION
## 변경 사항
- 1. 장소창 Arrow 버튼추가 
- 2. 내용칸은 더보기 - 접기 삭제(주석처리) -> 내용칸은 처음 사용자가 볼때 다보여야 하는게 맞는거 같습니다.


## 참고사항
<img width="316" alt="스크린샷 2022-10-25 오후 7 19 47" src="https://user-images.githubusercontent.com/104885097/197750573-55a21dcf-df6e-42b0-be0c-eb375c98e9d5.png">
<img width="326" alt="스크린샷 2022-10-25 오후 7 19 55" src="https://user-images.githubusercontent.com/104885097/197750648-816377a9-f666-43cb-8903-62332a70997b.png">



*참고로 Arrow 버튼은 장소텍스트 기준 왼쪽에 배치하였습니다. (오른쪽 배치시 복사버튼 이랑 인접하여 누르기 불편)
