### PR TITLE
fix: google toggleOff btn quick fix

### DIFF
--- a/frontend/kezuler-fe/src/components/common/GoogleToogleOn copy.tsx
+++ b/frontend/kezuler-fe/src/components/common/GoogleToogleOn copy.tsx
@@ -10,7 +10,7 @@ function GoogleToggleOff({ onClick, userEmail }: any) {
       <img src={GLogo} className="google-login-off-logo" />
       <div className="google-login-off-info">
         <div>Google</div>
-        <div className="google-login-off-info-gray">{userEmail}</div>
+        {/* <div className="google-login-off-info-gray">{userEmail}</div> */}
       </div>
       <div className="google-login-off-disconnect" onClick={onClick}>
         <DoNotDisturbAltIcon />


### PR DESCRIPTION
구글 연동 해제 버튼에서 나오는 계정이 구글계정이 아니라서 없앰