### PR TITLE
[#208] modify : 미팅 초대장 모임내용 나타내기

### DIFF
--- a/frontend/kezuler-fe/src/styles/AcceptMeeting.scss
+++ b/frontend/kezuler-fe/src/styles/AcceptMeeting.scss
@@ -5,11 +5,14 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-
+  &.is-nonMobile {
+    ::-webkit-scrollbar {
+      display: none;
+    }
+  }
   &.in-participants {
     margin-top: 0;
   }
-
   @media (max-height: $short-height-size) {
     margin-top: $app-bar-height--short;
   }
@@ -19,7 +22,9 @@
 
 .invitation {
   overflow-y: scroll;
-  height: 120vh;
+  &.is-mobile {
+    height: 120vh;
+  }
 }
 
 .invitation-message {

--- a/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
+++ b/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { isMobile } from 'react-device-detect';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { Avatar } from '@mui/material';
@@ -77,7 +78,11 @@ function Invitation() {
   const unloginButtonText = '카카오로 계속하기';
 
   return (
-    <div className={'invitation'}>
+    <div
+      className={classNames('invitation', {
+        'is-mobile': isMobile,
+      })}
+    >
       <div className={'invitation-info'}>
         <div className={'invitation-message'}>
           <b>{eventHost.userName}</b>

--- a/frontend/kezuler-fe/src/views/accept-meeting/index.tsx
+++ b/frontend/kezuler-fe/src/views/accept-meeting/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
+import { isMobile } from 'react-device-detect';
 import { useDispatch, useSelector } from 'react-redux';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { CircularProgress } from '@mui/material';
@@ -74,6 +75,7 @@ function AcceptMeeting() {
     <div
       className={classNames('accept-wrapper', {
         'in-participants': isInParticipants,
+        'is-nonMobile': !isMobile,
       })}
     >
       {isLoaded ? (


### PR DESCRIPTION
## 변동사항
1. 미팅 내용 eventDescription 이 존재할 경우 초대장에서 미팅내용을 확인 할 수 있습니다.
2. bottomPopper와 겹칠때 내용 확인 가능해야하므로 -> mobile 일경우 height 120 vh로 설정 
3. PC 일경우는 bottomPopper 때문에 내용을 못보는 일은 없을듯 함

## 참고사항
1. 모바일이 아닐경우 scroll diplay-none