### PR TITLE
update: design for calendar pair btn

### DIFF
--- a/frontend/kezuler-fe/src/components/accept-meeting/CalendarPairBtn.tsx
+++ b/frontend/kezuler-fe/src/components/accept-meeting/CalendarPairBtn.tsx
@@ -88,7 +88,6 @@ function CalendarPairBtn({ setIsCalendarPaired }: Props) {
       <div className={'calendar-pair-ask-btn'} onClick={handleGooglelogin}>
         <GoogleIcon />
         <span className={'btn-txt'}>일정 불러오기</span>
-        {/* <span className={'btn-txt'}>불러오기</span> */}
       </div>
     </div>
   );

--- a/frontend/kezuler-fe/src/styles/common/TimeLineGrid.scss
+++ b/frontend/kezuler-fe/src/styles/common/TimeLineGrid.scss
@@ -260,11 +260,12 @@
     box-shadow: 0px 15px 35px #282f390d;
     opacity: 1;
     color: $color-highlight;
-    background-color: #fad94f;
+    background-color: $color-main;
     cursor: pointer;
     display: flex;
     justify-content: center;
     align-items: center;
+
     @media (min-width: 360px) {
       padding-inline: 8px;
       font-size: 11px;


### PR DESCRIPTION
### 변경사항
---
<img width="131" alt="스크린샷 2022-11-01 오후 5 38 15" src="https://user-images.githubusercontent.com/41234227/199192978-22916ea9-34d2-4021-aa82-82dcf0146c05.png">
미팅 선택지가 있는 화면에서 캘린더 연동 버튼을 더 눈에 띄게 위와 같이 변경하였습니다.