### PR TITLE
[#208] modify : 미팅 초대장 미팅 내용 나타내기

### DIFF
--- a/frontend/kezuler-fe/src/styles/AcceptMeeting.scss
+++ b/frontend/kezuler-fe/src/styles/AcceptMeeting.scss
@@ -22,9 +22,6 @@
 
 .invitation {
   overflow-y: scroll;
-  &.is-mobile {
-    height: 120vh;
-  }
 }
 
 .invitation-message {
@@ -74,6 +71,12 @@
     margin-top: 40px;
     padding: 16px;
   }
+
+  .invitation-section-wrapper {
+    display: flex;
+    flex-direction: row;
+  }
+
   .invitation-title-place {
     font-size: $font-14;
     line-height: 17px;
@@ -98,12 +101,30 @@
       margin-top: 4px;
     }
   }
+
+  .invitation-description-text-ellipsis {
+    height: 30px;
+    overflow: auto;
+    overflow-y: hidden;
+    margin-top: 8px;
+    font-size: $font-16;
+    line-height: 21px;
+    word-break: break-word;
+    white-space: pre-line;
+    @media (max-width: 340px) {
+      margin-top: 4px;
+    }
+    background: linear-gradient(to bottom, #000000, #f9f9f9);
+    color: transparent;
+    background-clip: text;
+  }
+
   .invitation-description-text {
     margin-top: 8px;
     font-size: $font-16;
     line-height: 21px;
+    word-break: break-word;
     white-space: pre-line;
-    overflow-x: scroll;
     @media (max-width: 340px) {
       margin-top: 4px;
     }
@@ -124,6 +145,38 @@
     .invitation-place-text {
       padding-left: 6px;
       word-break: break-all;
+    }
+  }
+
+  .invitation-showmore {
+    display: flex;
+    flex-direction: row;
+    border: 1px solid black;
+    border-radius: 7px;
+    padding: 4px 2px 4px 6px;
+    margin-top: 11px;
+    margin-left: 10px;
+    cursor: pointer;
+    @media (max-width: 340px) {
+      margin-top: 3px;
+    }
+
+    .invitation-showmore-text {
+      font-size: $font-14;
+      line-height: 17px;
+      color: #9f9f9f;
+      @media (max-width: 340px) {
+        font-size: $font-12;
+      }
+    }
+
+    .invitation-showmore-icon {
+      font-size: $font-18;
+      line-height: 17px;
+      color: #9f9f9f;
+      @media (max-width: 340px) {
+        font-size: $font-16;
+      }
     }
   }
 }

--- a/frontend/kezuler-fe/src/styles/OverviewModal.scss
+++ b/frontend/kezuler-fe/src/styles/OverviewModal.scss
@@ -271,7 +271,7 @@
 
       &.is-ellipsis {
         color: $color-66;
-        margin-right: 0px;
+        margin-right: 4px;
         width: 20px;
         height: 20px;
         cursor: pointer;

--- a/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
+++ b/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
@@ -1,7 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { Avatar } from '@mui/material';
 import classNames from 'classnames';
 
@@ -46,6 +48,19 @@ function Invitation() {
     [eventHost.userId]
   );
 
+  const [isEllipsis, setIsEllipsis] = useState(false);
+  const [scrollHeight, setScrollHeight] = useState(0);
+  const [finalHeight, setFinalHeight] = useState(0);
+
+  useEffect(() => {
+    if (eventDescription.split('\\n')[1]) setIsEllipsis(true);
+    else setIsEllipsis(false);
+    setScrollHeight(
+      Number(document.getElementById('text-ellipsis')?.scrollHeight)
+    );
+    setFinalHeight(scrollHeight + window.innerHeight);
+  }, [scrollHeight]);
+
   const handleNextClick = () => {
     if (isHost) {
       dispatch(
@@ -82,6 +97,7 @@ function Invitation() {
       className={classNames('invitation', {
         'is-mobile': isMobile,
       })}
+      style={isEllipsis ? { height: 'auto' } : { height: finalHeight }}
     >
       <div className={'invitation-info'}>
         <div className={'invitation-message'}>
@@ -111,12 +127,42 @@ function Invitation() {
           </div>
           {eventDescription ? (
             <>
-              <div className={classNames('invitation-title-place', 'place')}>
-                {meetingDescription}
+              <div className={classNames('invitation-section-wrapper')}>
+                <div className={classNames('invitation-title-place', 'place')}>
+                  {meetingDescription}
+                </div>
+                <div
+                  className={classNames('invitation-showmore')}
+                  onClick={() => setIsEllipsis((prev) => !prev)}
+                >
+                  <span className={classNames('invitation-showmore-text')}>
+                    {isEllipsis ? '펼쳐보기' : '접기'}
+                  </span>
+                  {isEllipsis ? (
+                    <KeyboardArrowDownIcon
+                      className={classNames('invitation-showmore-icon')}
+                    />
+                  ) : (
+                    <KeyboardArrowUpIcon
+                      className={classNames('invitation-showmore-icon')}
+                    />
+                  )}
+                </div>
               </div>
-              <div className={'invitation-description-text'}>
-                {eventDescription.replaceAll('\\n', '\n')}
-              </div>
+              {isEllipsis ? (
+                <>
+                  <div
+                    id="text-ellipsis"
+                    className={'invitation-description-text-ellipsis'}
+                  >
+                    {eventDescription.replaceAll('\\n', '\n')}
+                  </div>
+                </>
+              ) : (
+                <div className={'invitation-description-text'}>
+                  {eventDescription.replaceAll('\\n', '\n')}
+                </div>
+              )}
             </>
           ) : null}
         </div>


### PR DESCRIPTION
## 변동사항
1. 펼쳐보기- 접기로 구성하였습니다.
2. scroll height 측정하여 펼쳤을때 height 변경
3. 미팅내용이 2줄 이상일때 1.5 줄이 먼저 보이게하여 내용이 더있다는걸 확인
<img width="445" alt="스크린샷 2022-11-02 오전 11 55 28" src="https://user-images.githubusercontent.com/104885097/199385243-1e55530b-6cdf-4cf6-92f8-68e3e9cbd56e.png">
4.

## 참고사항
미팅내용 짤린것 linear-gradient
`background: linear-gradient(to bottom, #000000, #f9f9f9);`
