### PR TITLE
[#215]fix: calendar schedules overlap when disabled google connection

### DIFF
--- a/frontend/kezuler-fe/src/reducers/calendarList.ts
+++ b/frontend/kezuler-fe/src/reducers/calendarList.ts
@@ -24,5 +24,5 @@ const reducers = {
 
 const calendarSlice = createSlice({ name, initialState, reducers });
 
-export const calendarAction = calendarSlice.actions;
+export const calendarActions = calendarSlice.actions;
 export default calendarSlice.reducer;

--- a/frontend/kezuler-fe/src/utils/getCalendar.ts
+++ b/frontend/kezuler-fe/src/utils/getCalendar.ts
@@ -1,6 +1,6 @@
 import { useDispatch } from 'react-redux';
 
-import { calendarAction } from 'src/reducers/calendarList';
+import { calendarActions } from 'src/reducers/calendarList';
 import { AppDispatch } from 'src/store';
 import {
   PGetCalendarByDay,
@@ -24,7 +24,7 @@ type EventTimeListByDateWithPossibleNum = {
 const getSchedules = (eventTimeList: EventTimeListByDateWithPossibleNum) => {
   const dispatch = useDispatch<AppDispatch>();
   const dateKeys = Object.keys(eventTimeList);
-  const { setCalendarList } = calendarAction;
+  const { setCalendarList } = calendarActions;
 
   const dateToGetList = dateKeys.map((dateKey) => {
     const dateToGet: PGetCalendarByDay = {

--- a/frontend/kezuler-fe/src/views/accept-meeting/TimeListSelector.tsx
+++ b/frontend/kezuler-fe/src/views/accept-meeting/TimeListSelector.tsx
@@ -14,6 +14,7 @@ import {
 } from 'src/hooks/usePendingEvent';
 import { RootState } from 'src/reducers';
 import { acceptMeetingActions } from 'src/reducers/AcceptMeeting';
+import { calendarActions } from 'src/reducers/calendarList';
 import { participantsPopupAction } from 'src/reducers/ParticipantsPopup';
 import { AppDispatch } from 'src/store';
 import { PDeletePendingEvent, PPutPendingEvent } from 'src/types/pendingEvent';
@@ -47,6 +48,7 @@ function TimeListSelector({ isModification }: Props) {
   const { calendarList } = useSelector(
     (state: RootState) => state.calendarList
   );
+  const { destroy: destroyCalendar } = calendarActions;
   const {
     addAvailableTimes,
     deleteAvailableTimes,
@@ -80,6 +82,9 @@ function TimeListSelector({ isModification }: Props) {
     if (isModificationfunc(eventTimeCandidates, declinedUsers)) {
       navigate(`/modify/${eventId}`);
     }
+    return () => {
+      dispatch(destroyCalendar());
+    };
   }, []);
 
   const handlePutClick = () => {

--- a/frontend/kezuler-fe/src/views/pending-event/TimeConfirmator.tsx
+++ b/frontend/kezuler-fe/src/views/pending-event/TimeConfirmator.tsx
@@ -9,6 +9,7 @@ import useDialog from 'src/hooks/useDialog';
 import { usePostFixedEvent } from 'src/hooks/useFixedEvent';
 import { useGetPendingEvent } from 'src/hooks/usePendingEvent';
 import { RootState } from 'src/reducers';
+import { calendarActions } from 'src/reducers/calendarList';
 import { confirmTimeActions } from 'src/reducers/ConfirmTime';
 import { participantsPopupAction } from 'src/reducers/ParticipantsPopup';
 import { AppDispatch } from 'src/store';
@@ -55,10 +56,12 @@ function TimeConfirmator() {
 
   const { googleToggle } = useMemo(() => ({ ...getCurrentUserInfo() }), []);
   const [isCalendarPaired, setIsCalendarPaired] = useState(googleToggle);
+  const { destroy: destroyCalendar } = calendarActions;
 
   useEffect(() => {
     return () => {
       dispatch(destroy());
+      dispatch(destroyCalendar());
     };
   }, []);
 


### PR DESCRIPTION
### 변경사항
***
캘린더 리덕스 저장소를 캘린더 일정 보기가 끝난 경우에 초기화하여 캘린더 연동 해제 이후에 일정이 오버랩되어 보이는 현상 해결