### PR TITLE
[#208] modify : 미팅 초대장 미팅 내용 나타내기

### DIFF
--- a/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
+++ b/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
@@ -33,6 +33,7 @@ function Invitation() {
     eventId,
     eventHost,
     eventTitle,
+    eventDescription,
     addressType,
     addressDetail,
     eventTimeCandidates,


### PR DESCRIPTION
## 변동사항
1. 펼쳐보기- 접기로 카드 최하단 배치
2. scroll height 측정하여 펼쳤을때 height 변경
3. 미팅내용이 2줄 이상일때 1.5 줄이 먼저 보이게하여 내용이 더있다는걸 확인

## 참고사항
미팅내용 짤린것 linear-gradient
`background: linear-gradient(to bottom, #000000, #f9f9f9);`
참조링크또한 넣을 예정입니다.