### PR TITLE
[#208] modify : 미팅 초대장 미팅 내용 나타내기-R1

### DIFF
--- a/frontend/kezuler-fe/src/styles/AcceptMeeting.scss
+++ b/frontend/kezuler-fe/src/styles/AcceptMeeting.scss
@@ -145,16 +145,22 @@
     }
 
     .invitation-place-text {
+      width: 100%;
       padding-left: 6px;
-      overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      word-break: break-all;
       &.is-ellipsis {
         padding-left: 2px;
       }
       &.is-fold {
-        overflow: scroll;
+        text-overflow: clip;
         white-space: normal;
+        word-break: break-all;
+        word-wrap: normal;
+      }
+
+      span {
         word-break: break-all;
       }
     }

--- a/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
+++ b/frontend/kezuler-fe/src/views/accept-meeting/Invitation.tsx
@@ -56,9 +56,10 @@ function Invitation() {
   const [foldEllipsis, setFoldEllipsis] = useState(false);
 
   useEffect(() => {
-    if (eventDescription.split('\\n')[1]) setIsEllipsis(true);
-    if (eventDescription.split('\\n')[2]) setIsShowMoreNeed(true);
-    else setIsEllipsis(false);
+    if (eventDescription.split('\\n')[1]) {
+      setIsEllipsis(true);
+      setIsShowMoreNeed(true);
+    } else setIsEllipsis(false);
 
     if (Number(document.getElementById('text-ellipsis')?.clientHeight) > 0)
       setScrollHeight(
@@ -212,11 +213,19 @@ function Invitation() {
               {addressType === 'OFF' ? (
                 addressDetail
               ) : (
-                <a href={addressDetail} target="_blank" rel="noreferrer">
-                  <span>{addressDetail}</span>
-                </a>
+                <>
+                  {addressDetail ? (
+                    <>
+                      <a href={addressDetail} target="_blank" rel="noreferrer">
+                        <span>{addressDetail}</span>
+                      </a>
+                      <div />
+                    </>
+                  ) : (
+                    <span>{'온라인'}</span>
+                  )}
+                </>
               )}
-              {/* {addressDetail} */}
             </div>
           </div>
           {eventDescription ? (


### PR DESCRIPTION
## 변동사항
1. 펼쳐보기- 접기로 카드 최하단 배치
2. scroll height 측정하여 펼쳤을때 height 변경
3. 미팅내용이 2줄 이상일때 1.5 줄이 먼저 보이게하여 내용이 더있다는걸 확인
4. [R1] 온라인 모임인데 장소 안 적은 경우 -> "온라인"
5. [R1] a tag , word break 수정

## 참고사항
미팅내용 짤린것 linear-gradient
`background: linear-gradient(to bottom, #000000, #f9f9f9);`
참조링크또한 넣을 예정입니다.