### PR TITLE
hotfix: pc view overview partivipants max num 5 to 4

### DIFF
--- a/frontend/kezuler-fe/src/components/main-page/overview-modal/OverviewParticipants.tsx
+++ b/frontend/kezuler-fe/src/components/main-page/overview-modal/OverviewParticipants.tsx
@@ -61,7 +61,7 @@ function OverviewParticipants({ event }: Props) {
   }, []);
 
   const MAX_PREVIEW_NUM = useMemo(() => {
-    if (windowSize.innerWidth > 440) {
+    if (windowSize.innerWidth > 440 && windowSize.innerWidth < 800) {
       return 5;
     } else if (windowSize.innerWidth > 400) {
       return 4;


### PR DESCRIPTION
## 변경사항
데스크탑 뷰에서 사람 수가 5명 보이는 것을 max로 해놨더니 깨지는 현상 발생
데스크탑에서는 414px이 너비인 모바일 화면처럼 보여주므로 이 사항을 반영하여 수정함
